### PR TITLE
Align ESPHome configs and common includes

### DIFF
--- a/esphome/bedjet.yaml
+++ b/esphome/bedjet.yaml
@@ -20,9 +20,15 @@ ota:
 
 esp32_ble_tracker:
 
+logger:
+  logs:
+    esp32_ble_client: ERROR
+
 #text_sensor:
 #  - platform: ble_scanner
 #    name: "BLE Devices Scanner"
+
+mqtt: !remove
 
 ble_client:
   - mac_address: 08:D1:F9:0A:B9:0A

--- a/esphome/common/base.yaml
+++ b/esphome/common/base.yaml
@@ -12,6 +12,12 @@ ota:
     id: ota_esphome
     password: !secret ota
 
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  log_topic: "${devicename}/log"
+
 time:
   - platform: homeassistant
     id: homeassistant_time

--- a/esphome/common/device-classes/d1_mini_max6675.yaml
+++ b/esphome/common/device-classes/d1_mini_max6675.yaml
@@ -1,21 +1,32 @@
-esphome:
-  name: "${devicename}"
-  platform: ESP8266
-  board: d1_mini
+# Wiring info
+#
+# +------------+------------+----------------+------------+-----------------+
+# | MAX6675    | Wire Color | D1 Mini Pin    | GPIO       | Function        |
+# +------------+------------+----------------+------------+-----------------+
+# | GND        | Brown      | G (GND)        | -          | Ground          |
+# | VCC        | Red        | VCC (3.3V)     | -          | 3.3V Power      |
+# | SCK        | Orange     | D5             | GPIO14     | SPI Clock (CLK) |
+# | CS         | Green      | D8             | GPIO15     | Chip Select (CS)|
+# | SO         | Yellow     | D6             | GPIO12     | SPI MISO        |
+# +------------+------------+----------------+------------+-----------------+
+  esphome:
+    name: "${devicename}"
+    platform: ESP8266
+    board: d1_mini
 
-# Enable logging
-logger:
+  # Enable logging
+  logger:
 
-spi:
-  miso_pin: D6
-  clk_pin: D5
+  spi:
+    miso_pin: D6
+    clk_pin: D5
 
-sensor:
-  - platform: max6675
-    id: max6675_1
-    name: "${human_devicename} Temperature"
-    cs_pin: D8
-    update_interval: 15s
-  - platform: copy
-    source_id: max6675_1
-    name: "${human_devicename} Temperature 2"
+  sensor:
+    - platform: max6675
+      id: max6675_1
+      name: "${human_devicename} Temperature"
+      cs_pin: D8
+      update_interval: 15s
+    - platform: copy
+      source_id: max6675_1
+      name: "${human_devicename} Temperature 2"

--- a/esphome/common/wifi.yaml
+++ b/esphome/common/wifi.yaml
@@ -17,3 +17,7 @@ sensor:
     name: "${human_devicename} WiFi Signal"
     update_interval: 60s
     icon: mdi:wifi
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "${human_devicename} IP Address"

--- a/esphome/freezer-door.yaml
+++ b/esphome/freezer-door.yaml
@@ -116,7 +116,7 @@ interval:
           then:
             - output.turn_on: status_led
           else:
-            - output.turn_off: status_led          
+            - output.turn_off: status_led
 
 script:
   - id: reset_timer

--- a/esphome/k2-power.yaml
+++ b/esphome/k2-power.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 packages:
   wifi: !include common/wifi.yaml
+  web: !include common/web.yaml
   base: !include common/base.yaml
   sonoff_s31: !include common/device-classes/sonoff_s31.yaml
 

--- a/esphome/k5-power.yaml
+++ b/esphome/k5-power.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 packages:
   wifi: !include common/wifi.yaml
+  web: !include common/web.yaml
   base: !include common/base.yaml
   sonoff_s31: !include common/device-classes/sonoff_s31.yaml
 

--- a/esphome/szamar-power.yaml
+++ b/esphome/szamar-power.yaml
@@ -1,7 +1,7 @@
 substitutions:
-  devicename: s31-blank-2
-  device_id: s31_blank_2
-  human_devicename: S31 Blank 2
+  devicename: szamar-power
+  device_id: szamar_power
+  human_devicename: Szamar Power
   icon: mdi:checkbox-blank-outline
 
 packages:


### PR DESCRIPTION
- Add MQTT secrets block to common/base.yaml
- Add WiFi IP text_sensor in common/wifi.yaml
- BedJet: set BLE client log level and remove MQTT
- Include web package in k2/k5 power configs
- Rename Szamar Power substitutions
- Tidy trailing space in freezer-door.yaml
- Reformat d1_mini_max6675 with wiring notes