### PR TITLE
Add direnv setup for Home Assistant development

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+# Load nix development environment
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
+fi
+
+use flake
+
+# Add all scripts directories to PATH
+PATH_add scripts

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.vscode
 /.esphome/
+.direnv/
 **/.pioenvs/
 **/.piolibdeps/
 **/lib/


### PR DESCRIPTION
- Add .envrc to load nix development environment automatically
- Add .direnv/ to .gitignore to exclude generated direnv state

This enables automatic environment setup when entering the repository.
