### PR TITLE
Add temperature alerts for new sensors

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -330,14 +330,27 @@ template:
         state: >
           {% set p = states('sensor.washing_machine_electric_consumption_w')|float(0) %}
           {% set was_on = (this.state == 'on') %}
-          {{ p > 18 or (was_on and p > 8) }}
+          {{ p > 18 or (was_on and p > 5) }}
         delay_on:
           seconds: 10
         delay_off:
-          minutes: 3
+          seconds: 10
         availability: >
           {{ states('sensor.washing_machine_electric_consumption_w')|float(-1) >= 0 }}
-          
+  # This exists to give Alexa a clean motion sensor event when the washer finishes
+  # so it can announce it.  The debounce is done in the washer_running sensor above.
+  - trigger:
+      - platform: state
+        entity_id: binary_sensor.washer_running
+        to: "off"        # no extra 'for:' needed; you already debounce via delay_off
+    binary_sensor:
+      - name: "Washer Done (Alexa)"
+        unique_id: washer_done_alexa
+        device_class: motion
+        state: "true"
+        auto_off:
+          seconds: 3     # self-resets so each finish creates a clean edge
+
 input_number:
   moisture_base: &moisture_base
     min: 0
@@ -506,6 +519,27 @@ binary_sensor:
         value_template: >
           {{ states("sensor.freezer_temperature") | float(999.0) == 999.0
              or states("sensor.freezer_temperature") | float > 25 }}
+      garage_freezer_too_warm:
+        friendly_name: "Garage Freezer Too Warm"
+        device_class: problem
+        delay_on: "00:20:00"
+        value_template: >
+          {{ states("sensor.garage_freezer_temperature") | float(999.0) == 999.0
+             or states("sensor.garage_freezer_temperature") | float > 10 }}
+      refrigerator_too_warm:
+        friendly_name: "Refrigerator Too Warm"
+        device_class: problem
+        delay_on: "00:20:00"
+        value_template: >
+          {{ states("sensor.refrigerator_temperature") | float(999.0) == 999.0
+             or states("sensor.refrigerator_temperature") | float > 47 }}
+      refrigerator_freezer_too_warm:
+        friendly_name: "Refrigerator Freezer Too Warm"
+        device_class: problem
+        delay_on: "00:20:00"
+        value_template: >
+          {{ states("sensor.refrigerator_freezer_temperature") | float(999.0) == 999.0
+             or states("sensor.refrigerator_freezer_temperature") | float > 0 }}
       freezer_door_open_delayed:
         friendly_name: "Freezer Door Open Too Long"
         delay_on: "00:05:00"
@@ -564,6 +598,27 @@ alert:
   freezer_too_warm:
     name: "Temperature in the freezer is too warm!"
     entity_id: binary_sensor.freezer_too_warm
+    state: "on"
+    repeat: 10
+    notifiers:
+    - call_me
+  garage_freezer_too_warm:
+    name: "Temperature in the garage freezer is too warm!"
+    entity_id: binary_sensor.garage_freezer_too_warm
+    state: "on"
+    repeat: 10
+    notifiers:
+    - call_me
+  refrigerator_too_warm:
+    name: "Temperature in the refrigerator is too warm!"
+    entity_id: binary_sensor.refrigerator_too_warm
+    state: "on"
+    repeat: 10
+    notifiers:
+    - call_me
+  refrigerator_freezer_too_warm:
+    name: "Temperature in the refrigerator freezer is too warm!"
+    entity_id: binary_sensor.refrigerator_freezer_too_warm
     state: "on"
     repeat: 10
     notifiers:


### PR DESCRIPTION
## Temperature Alerts

Adds phone call alerts for three new temperature sensors based on historical data analysis:

- **Garage freezer**: Alert if > 10°F for 20 minutes (historical max: 6.08°F)
- **Refrigerator**: Alert if > 47°F for 20 minutes (historical max: 43.3°F)  
- **Refrigerator freezer**: Alert if > 0°F for 20 minutes (historical max: -3.1°F)

Thresholds are conservative to avoid false alarms from brief door openings while catching real problems like compressor failures or power loss.

## Washer Sensor Improvements

- Tightened detection thresholds for more reliable washer running detection
- Added "Washer Done" motion sensor for Alexa announcements